### PR TITLE
Fix weakdes_gfp.cc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Binaries
 *
 
+# Exception README.md
+!README.md
+
 # Prerequisites
 *.d
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,40 @@
+# Binaries
+*
+
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Artifacts
+.rcxxflags
+.rldflags
+generated/*.inc

--- a/1bitext_rsh.cc
+++ b/1bitext_rsh.cc
@@ -177,7 +177,7 @@ void bitext_rsh::create_coefficients() {
 			  sizeof(chunk_t)*vec.size()/sizeof(char), coeffs[i]);
 		if (debug_level >= EXCESSIVE_INFO) {
 			cerr << "RSH Coefficient " << i << "(" << r << "): "
-			     << BN_bn2dec(coeffs[i]) << cerr << endl;
+			     << BN_bn2dec(coeffs[i]) << endl;
 		}
 #endif
 	}

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ all.objects = $(objects) $(objects.ext) $(objects.r)
 headers = 1bitext.h debug.h timing.h weakdes_gf2x.h weakdes_gfp.h weakdes_block.h \
 	  utils.hpp weakdes.h bitfield.hpp
 platform=$(shell uname)
-INCDIRS=-I/usr/include/openssl-1.0/
+INCDIRS=-I/usr/include/openssl-1.0/ -I/usr/lib/R/library/RInside/include/ -I/usr/lib/R/library/Rcpp/include/ -I/usr/include/R/
 LIBDIRS=-L/usr/lib/openssl-1.0/
 CXXFLAGS=$(OPTIMISE) $(OPENMP) $(DEBUG) $(VARIANTS) $(INCDIRS)
 ifeq ($(HAVE_SSE4),y)

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,10 @@ extractor: $(all.objects) extractor.cc $(headers) .rldflags .rcxxflags
 	$(CXX) $(CXXFLAGS) $(shell cat .rcxxflags) extractor.cc $(all.objects) -o extractor \
 	$(LIBDIRS) $(LIBS) $(shell cat .rldflags)
 
+test_design: $(all.objects) test_weakdes_gfp.cpp $(headers) .rldflags .rcxxflags
+	$(CXX) $(CXXFLAGS) $(shell cat .rcxxflags) test_weakdes_gfp.cpp weakdes_gfp.o -o test_weakdes_gfp \
+	$(LIBDIRS) $(LIBS) $(shell cat .rldflags)
+
 figures: | paper/pictures
 	@echo "Generating figures..."
 	@R CMD BATCH plot_params.r

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ all.objects = $(objects) $(objects.ext) $(objects.r)
 headers = 1bitext.h debug.h timing.h weakdes_gf2x.h weakdes_gfp.h weakdes_block.h \
 	  utils.hpp weakdes.h bitfield.hpp
 platform=$(shell uname)
-#INCDIRS=-I/opt/local/include
-#LIBDIRS=-L/opt/local/lib
+INCDIRS=-I/usr/include/openssl-1.0/
+LIBDIRS=-L/usr/lib/openssl-1.0/
 CXXFLAGS=$(OPTIMISE) $(OPENMP) $(DEBUG) $(VARIANTS) $(INCDIRS)
 ifeq ($(HAVE_SSE4),y)
 CXXFLAGS+=-msse4.2 -DHAVE_SSE4

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ HAVE_SSE4=y
 HAVE_GF2X=n
 
 ###### Nothing user-configurable below here ########
-.PHONY: all clean paper src-pdf figures notes
+.PHONY: all clean src-pdf figures
 all: extractor
 BITEXTS = 1bitext_xor.o 1bitext_expander.o 1bitext_rsh.o
 WDS = weakdes_gf2x.o weakdes_gfp.o weakdes_aot.o weakdes_block.o
@@ -26,9 +26,8 @@ all.objects = $(objects) $(objects.ext) $(objects.r)
 headers = 1bitext.h debug.h timing.h weakdes_gf2x.h weakdes_gfp.h weakdes_block.h \
 	  utils.hpp weakdes.h bitfield.hpp
 platform=$(shell uname)
-INCDIRS=-I/opt/local/include
-INCDIRS+=-I/Users/wolfgang/src/openssl-1.0.1c/include
-LIBDIRS=-L/opt/local/lib
+#INCDIRS=-I/opt/local/include
+#LIBDIRS=-L/opt/local/lib
 CXXFLAGS=$(OPTIMISE) $(OPENMP) $(DEBUG) $(VARIANTS) $(INCDIRS)
 ifeq ($(HAVE_SSE4),y)
 CXXFLAGS+=-msse4.2 -DHAVE_SSE4
@@ -89,12 +88,6 @@ extractor: $(all.objects) extractor.cc $(headers) .rldflags .rcxxflags
 	$(CXX) $(CXXFLAGS) $(shell cat .rcxxflags) extractor.cc $(all.objects) -o extractor \
 	$(LIBDIRS) $(LIBS) $(shell cat .rldflags)
 
-# NOTE: This is separated from the paper target on purpose. Generating the
-# figures takes long compared to TeXing the paper, and the inputs rarely change.
-# A proper solution would be to write the paper in Sweave and use cacheSweave,
-# but for the moment, the extra complexity does not seem worth it.
-# NOTE: Did not bother to check if the source files are more up-to-date than
-# the pictures. They are always (re)generated when this target is run
 figures: | paper/pictures
 	@echo "Generating figures..."
 	@R CMD BATCH plot_params.r
@@ -106,15 +99,6 @@ figures: | paper/pictures
 paper/pictures:
 	@mkdir -p paper/pictures
 
-paper:
-	$(MAKE) -C paper
-
-arxiv:
-	$(MAKE) -C paper arxiv && mv paper/arxiv.tar .
-
-notes:
-	$(MAKE) -C notes
-
 src-pdf:
 	enscript -E -G -j *.h *.cc *.hpp *.r \
 	         -o /tmp/code.ps; ps2pdf /tmp/code.ps code.pdf
@@ -122,4 +106,3 @@ clean:
 	@rm -f *.o weakdes_test 1bitext_test extractor
 	@rm -rf generated/*
 	@rm -f .rldflags .rcxxflags
-	@$(MAKE) clean -C paper

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# libtrevisan
+
+## Dependencies
+- [NTL](https://libntl.org/): A C++ Library for doing Number Theory
+- [OpenSSL 1.0](https://github.com/openssl/openssl)
+- [RIndise](https://cran.r-project.org/web/packages/RInside/index.html): C++ classes to embed R in C++ (and C) applications
+- [TCLAP](https://tclap.sourceforge.net/): Small, flexible library that provides a simple interface for defining and accessing command line arguments
+
+
+### Arch Linux
+- [`r-rinside`](https://aur.archlinux.org/packages/r-rinside)
+- [`ntl`](https://archlinux.org/packages/extra/x86_64/ntl/)
+- [`openssl-1.0`](https://aur.archlinux.org/packages/openssl-1.0)
+- [`tclap`](https://archlinux.org/packages/extra/any/tclap/)

--- a/R_interp.h
+++ b/R_interp.h
@@ -37,15 +37,15 @@ public:
 	void eval_code(const std::string &code);
 	int parse_eval(const std::string &call, SEXP &ans);
 
+	// Delete the copy constructor and assignment operator to prevent copying
+	R_interp(const R_interp&) = delete;
+	R_interp& operator=(const R_interp&) = delete;
+
 private:
 	// Make sure there are no concurrent calls to the R sesson
 	static r_interp_lock_t r_lock;
 	static std::unique_ptr<RInside> r_interp;
 	static short instances; // Ensure there's only one R session
-
-	// Ensure that the object cannot be copied or assigned
-	R_interp& operator = (const R_interp& other) { }
-	R_interp(const R_interp& other) { }
 };
 
 #endif

--- a/bitfield.hpp
+++ b/bitfield.hpp
@@ -21,16 +21,16 @@ template<typename C, typename I>
 class bitfield {
 public:
 	bitfield() : data(nullptr), n(0) {
-		bits_per_type=sizeof(*data)*8;
+		bits_per_type=0;
 	};
 
 	bitfield(void *data, I n) {
-		bits_per_type=sizeof(*data)*8;
+		bits_per_type=sizeof(C)*8;
 		set_raw_data(data, n);
 	};
 
 	bitfield(C *data, I n) {
-		bits_per_type=sizeof(*data)*8;
+		bits_per_type=sizeof(C)*8;
 		this->data = data;
 		this->n = n;
 	};

--- a/extractor.cc
+++ b/extractor.cc
@@ -32,7 +32,7 @@
 #include "extractor.h"
 #include "prng.hpp"
 #include <tbb/tbb.h>
-#include <tbb/task_scheduler_init.h>
+#include <tbb/global_control.h>
 #include <RInside.h>
 
 using namespace TCLAP;
@@ -551,12 +551,11 @@ void show_params(struct params &params, bitext *bext, weakdes *wd) {
 /////////////////////////////////// Dispatcher /////////////////////////////
 int dispatch(struct params &params) {
 	int num_tasks;
-	num_tasks = tbb::task_scheduler_init::default_num_threads();
+	num_tasks = tbb::global_control::active_value(tbb::global_control::max_allowed_parallelism);
 	if (params.num_tasks > 0)
 		num_tasks = params.num_tasks;
 	else
 		params.num_tasks = num_tasks;
-	tbb::task_scheduler_init init(num_tasks);
 
 	// We rely on openssl being compiled with thread support
 #define OPENSSL_THREAD_DEFINES

--- a/extractor.cc
+++ b/extractor.cc
@@ -74,7 +74,7 @@ void *alloc_and_zero(size_t m) {
 // and weakdes. This makes the trevisan extractor algorithm
 // independent of the specific 1-bit-extractor and weak design
 // algorithms
-inline bool trevisan_extract(uint64_t i, vector<uint64_t> &indices,
+inline void trevisan_extract(uint64_t i, vector<uint64_t> &indices,
 			     bitfield<unsigned int, uint64_t> &init_rand_bf,
 			     unsigned int *y_S_i, params &params,
 			     wd_file_lock_type &wd_file_lock, bitext *bext, weakdes *wd,

--- a/extractor.cc
+++ b/extractor.cc
@@ -34,6 +34,12 @@
 #include <tbb/tbb.h>
 #include <tbb/global_control.h>
 #include <RInside.h>
+// We rely on openssl being compiled with thread support
+#define OPENSSL_THREAD_DEFINES
+#include <openssl/opensslconf.h>
+#ifndef OPENSSL_THREADS
+#error Please use a thread capable openssl
+#endif
 
 using namespace TCLAP;
 using namespace std;
@@ -556,13 +562,6 @@ int dispatch(struct params &params) {
 		num_tasks = params.num_tasks;
 	else
 		params.num_tasks = num_tasks;
-
-	// We rely on openssl being compiled with thread support
-#define OPENSSL_THREAD_DEFINES
-#include <openssl/opensslconf.h>
-#ifndef OPENSSL_THREADS
-#error Please use a thread capable openssl
-#endif
 
 	init_timekeeping();
 	init_openssl_locking();

--- a/test_weakdes_gfp.cpp
+++ b/test_weakdes_gfp.cpp
@@ -1,0 +1,41 @@
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <cstdint>
+#include "weakdes_gfp.h"
+
+int debug_level = 4;
+
+int main()
+{
+    size_t m = 30;
+    size_t t = 5;
+
+    class weakdes *wd;
+    wd = new weakdes_gfp;
+    wd->set_params(t, m);
+
+    long double r = wd->get_r();
+    size_t m_wd = wd->get_m();
+    size_t t_wd = wd->get_t();
+    std::cout << "r = " << r << std::endl;
+    std::cout << "m = " << m_wd << std::endl;
+    std::cout << "t = " << t_wd << "\n" << std::endl;
+
+    std::vector<uint64_t> indices;
+    indices.resize(t);
+
+    for (std::size_t i=0; i<m; ++i) {
+        wd->compute_Si(i, indices);
+
+        std::cout << "i = " << i << std::endl;
+        std::cout << "[ ";
+        for (std::size_t j=0; j<t; ++j) {
+            std::cout << indices[j] << " ";
+        }
+        std::cout << "]" << "\n" << std::endl;
+    }
+
+    delete wd;
+    return 0;
+}

--- a/weakdes_gfp.cc
+++ b/weakdes_gfp.cc
@@ -62,8 +62,11 @@ template <class T, class F>
 T weakdes_gfp::horner_poly(const vector<T> &coeffs, T x, T modulus, F inv_modulus) {
 	T res = 0;
  
-	for(size_t i = 0; i < coeffs.size(); i++) {
-	    res = multiply_mod(res, x, modulus, inv_modulus) + coeffs[i];
+	// BUG 3
+	//for(size_t i = 0; i < coeffs.size(); i++) {
+	// FIX BUG 3
+	for(int i = coeffs.size() - 1; i >= 0; --i) {
+		res = multiply_mod(res, x, modulus, inv_modulus) + coeffs[i];
 	}
 
 	// Since the coefficients are upper bounded by the modulus,
@@ -222,8 +225,11 @@ void weakdes_gfp::compute_Si(uint64_t i, vector<uint64_t> &indices) {
 	// NOTE: A polynomial of degree deg has deg+1 coefficients,
 	// so we need to iterate up to and _including_ deg.
 	for (count = 0; count <= deg; count++) {
-		coeff[count] = (i & (mask << (count*log_t))) >> count*log_t;
-		coeff[count] = coeff[count] % t;
+		// BUG 2
+		//coeff[count] = (i & (mask << (count*log_t))) >> count*log_t;
+		//coeff[count] = coeff[count] % t;
+		// FIX BUG 2
+		coeff[count] = i / (uint64_t)(pow(t, count)) % t;
 
 		if (debug_level >= EXCESSIVE_INFO)
 			cerr << "Coefficient " << count << ": " <<
@@ -247,6 +253,7 @@ void weakdes_gfp::compute_Si(uint64_t i, vector<uint64_t> &indices) {
 	for (a = 0; a < t_requested; a++) {
 		inv_t = (double)1/t;
 		res = horner_poly<uint64_t, double>(coeff, a, t, inv_t);
+
 
 		// Finally, generate the pair <a, poly(a)> as a concatenation
 		// of the bit values, which denotes one element of S_{i}.
@@ -278,8 +285,11 @@ void weakdes_gfp::compute_Si(uint64_t i, vector<uint64_t> &indices) {
 #endif
 
 		// Perform bitwise concatenation of a and poly(a)=res
-		res_num_tmp <<= log_t;
-		res_num |= res_num_tmp;
+		// BUG 1
+		//res_num_tmp <<= log_t;
+		//res_num |= res_num_tmp;
+		// FIX BUG 1
+		res_num += t * res;
 
 		// Although it is guaranteed that the concatenated
 		// result fits into to available number of bits, the


### PR DESCRIPTION
Current implementation of the basic construction of the weak design for Galois fields $GF(t)$, where $t$ is an arbitrary prime number, done in [`weakdes_gfp.cc`](https://github.com/wolfgangmauerer/libtrevisan/blob/master/weakdes_gfp.cc) contains two bugs that *affect the correctness* of the weak design (overlap constraint is violated) and one additional bug that does not affect correctness but deviates the implementation from the theoretical description in [arXiv:1212.0520](https://arxiv.org/abs/1212.0520) (III.B.1).

### Bug 1
https://github.com/wolfgangmauerer/libtrevisan/blob/0b706e87c367318ac4ad2863a9dbeada7afcdd2e/weakdes_gfp.cc#L280-L282

These two lines of code are implementing the map $(i, j)\rightarrow i + t\cdot j$ to go from $[t]\times [t]$ to $[d]$, where $d=t^2$ as desired.

The problem is that implementing the multiplication and addition with a left shift and OR operations, respectively, is only equivalent to the desired map when $t=2^k$ for some integer $k$, not for any prime number in general.

$$
a + 2^{\lceil\log t\rceil}\cdot p_i(a) \mod d \neq a + t\cdot p_i(a)\mod d\quad \forall t \text{  prime}.
$$

### Bug 2
https://github.com/wolfgangmauerer/libtrevisan/blob/0b706e87c367318ac4ad2863a9dbeada7afcdd2e/weakdes_gfp.cc#L218-L226

Similarly to the previous issue, here the coefficients $\alpha_{i,j}$ from the basic construction are computed using shift operators. The `mask` effectively selects the `log_t` least significant bits. This is used in the first calculation of `coeff[count]` (l. 225) to effectively compute an integer division. In the next line, the modulus is taken. Exactly for the same reason as above, the denominator only matches the desired $t$ when $t$ is a power of 2, not an arbitrary prime.

$$
\tilde{\alpha}_{i,j} := \left\lfloor \frac{i}{\left(2^{\lceil\log t\rceil}\right)^j}\right\rfloor \mod t \neq \left\lfloor\frac{i}{t^j}\right\rfloor \mod t =: \alpha\_{i,j}
$$

### Bug 3
https://github.com/wolfgangmauerer/libtrevisan/blob/0b706e87c367318ac4ad2863a9dbeada7afcdd2e/weakdes_gfp.cc#L62-L67
The polynomial evaluation using [Horner's method](https://en.wikipedia.org/wiki/Horner's_method) takes the coefficients in the same order as given. Effectively, this means that the $i$-th polynomial in the implementation is now

$$
\tilde{p}\_i(x) =  \sum\_{j=0}^{c} \alpha\_{i, c-j} x^j
$$
instead of
$$
p\_i(x) =  \sum\_{j=0}^{c} \alpha\_{i,j} x^j.
$$

This deviation probably does not affect the correctness of the weak design, but it is not was proved in [arXiv:1212.0520](https://arxiv.org/abs/1212.0520) (Appendix C.1) or [arXiv:1109.6147](https://arxiv.org/abs/1109.6147).

---
The relevant commit with the fixes for these bugs is https://github.com/wolfgangmauerer/libtrevisan/pull/2/commits/8b5281bf184a4ce389f0a89fdf8e4d1444732154. All other commits are small changes to make the software compile with our particular setup and can be ignored.

For completeness, a minimal example that demonstrate the impact of these issues is included in https://github.com/wolfgangmauerer/libtrevisan/commit/51b57ea605e57a92b59bbddfa80435c7e985778f.

For the simplest case, when $m=6$ and $t=2$, calculations are done by hand [here](https://randextract.crypto-lab.ch/theory/trevisan.html#a-basic-construction). The weak design should be:

![image](https://github.com/user-attachments/assets/9942b0b4-b5c7-4caf-a8e0-16bb8faec91b)

But current code always returns indices $[0 1]$.


